### PR TITLE
Brand CSS

### DIFF
--- a/brand/aramark-brand.css
+++ b/brand/aramark-brand.css
@@ -1,0 +1,34 @@
+:root {
+  --brand-colors-primary: #e87722;
+  --brand-colors-secondary: #003865;
+  --brand-colors-background: #ffffff;
+  --brand-colors-surface: #f5f5f5;
+  --brand-colors-error: #d32f2f;
+  --brand-colors-on-primary: #ffffff;
+  --brand-colors-on-secondary: #ffffff;
+  --brand-colors-text-primary: #212121;
+  --brand-colors-text-secondary: #757575;
+  --brand-typography-font-family-base: "Source Sans Pro", Arial, sans-serif;
+  --brand-typography-font-size-base: 16px;
+  --brand-typography-font-size-small: 12px;
+  --brand-typography-font-size-large: 20px;
+  --brand-typography-font-weight-regular: 400;
+  --brand-typography-font-weight-bold: 700;
+  --brand-typography-line-height-base: 1.5;
+  --brand-spacing-xs: 4px;
+  --brand-spacing-sm: 8px;
+  --brand-spacing-md: 16px;
+  --brand-spacing-lg: 24px;
+  --brand-spacing-xl: 32px;
+  --brand-spacing-xxl: 48px;
+  --brand-border-radius-small: 4px;
+  --brand-border-radius-medium: 8px;
+  --brand-border-radius-large: 16px;
+  --brand-border-radius-pill: 9999px;
+  --brand-shadows-card: 0 2px 4px rgba(0,0,0,0.12);
+  --brand-shadows-modal: 0 8px 24px rgba(0,0,0,0.2);
+  --brand-breakpoints-mobile: 480px;
+  --brand-breakpoints-tablet: 768px;
+  --brand-breakpoints-desktop: 1024px;
+  --brand-breakpoints-wide: 1280px;
+}


### PR DESCRIPTION
Adds `brand/aramark-brand.css` with 32 CSS custom properties generated from theme data.